### PR TITLE
Add escape_guardian CLI command for triggering escapeGuardian

### DIFF
--- a/paradex_cli/__init__.py
+++ b/paradex_cli/__init__.py
@@ -1,5 +1,5 @@
 from .main import (app, 
                    _change_guardian, _change_guardian_backup, _change_signer, 
                    _sign_invoke_tx, _submit_invoke_tx, load_contract_from_account, 
-                   _withdraw_to_l1, _transfer_on_l2, _deposit_to_paraclear
+                   _withdraw_to_l1, _transfer_on_l2, _deposit_to_paraclear, _escape_guardian
     )


### PR DESCRIPTION
This PR introduces a new CLI command `escape-guardian` that allows users to trigger the `escapeGuardian` method on their Starknet account contract after 7 days after calling trigger_escape_guardian.

- Added `_escape_guardian` async function
- Unit tests included for logic and CLI

Tested on local devnet and with mocked contract.