### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paradex-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "CLI for interacting with Paradex API and Paraclear smart contracts"
 authors = [{name = "Paradex Team", email = "support@paradex.trade"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -1069,7 +1069,7 @@ wheels = [
 
 [[package]]
 name = "paradex-cli"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "paradex-py" },


### PR DESCRIPTION
Version bump from 0.2.0 to 0.2.1.

Follows the EVM (Argent v0.4.0/v0.5.0) account + subkey management work merged in #25, which now requires `paradex_py>=0.6.2`.