### PR TITLE
ci: publish to PyPI via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      # Required for PyPI trusted publishing (OIDC) — no API token needed.
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout code
@@ -34,7 +39,5 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Publish to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish to PyPI (trusted publishing via OIDC)
         run: uv publish


### PR DESCRIPTION
## Why

The publish workflow failed with `403 Invalid or non-existent authentication information` because it authenticates with `secrets.PYPI_API_TOKEN`, which no longer exists in the repo or org (the org now standardises on OIDC-based auth). The 0.1.x releases predate that secret's removal.

## What

Port the same tokenless flow paradex-py already uses — **PyPI trusted publishing via OIDC**:

- Add `permissions: id-token: write` (+ `contents: read`) so GitHub mints the OIDC token `uv publish` exchanges with PyPI.
- Add `environment: prod` (matches paradex-py).
- Drop the `UV_PUBLISH_TOKEN` / `PYPI_API_TOKEN` secret entirely.

The tag trigger (`v*.*.*`) and the tag-vs-pyproject version check are unchanged.

## Follow-up (admin, one-time)

Register a trusted publisher for the `paradex-cli` project on PyPI: repo `tradeparadex/paradex-cli`, workflow `publish.yml`, environment `prod` — exactly as configured for paradex-py. Until that's registered, publish will still be rejected.